### PR TITLE
Add CandidateForm validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Running Tests
+
+This project uses Jest with React Testing Library.
+Execute all tests with:
+
+```bash
+npm test
+```

--- a/__tests__/candidateForm.test.jsx
+++ b/__tests__/candidateForm.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CandidateForm from "@/app/forms/candidateForm";
+import axios from "axios";
+
+jest.mock("axios");
+
+describe("CandidateForm validation", () => {
+  beforeEach(() => {
+    axios.get.mockResolvedValue({ data: [] });
+    axios.post.mockResolvedValue({});
+  });
+
+  test("shows validation errors when submitting empty form", async () => {
+    render(<CandidateForm />);
+
+    await userEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    expect(await screen.findByText("Full name is required")).toBeInTheDocument();
+    expect(await screen.findByText("Mobile number must be 10 digits")).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+const nextJest = require('next/jest')
+const createJestConfig = nextJest({ dir: './' })
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom'
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",
@@ -24,6 +25,11 @@
   },
   "devDependencies": {
     "eslint": "^8",
-    "eslint-config-next": "15.0.2"
+    "eslint-config-next": "15.0.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.1",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest using `next/jest`
- add `CandidateForm` unit test
- document test instructions in README
- include new test dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa0b2596083309da54d8e9ad9257c