### PR TITLE
Add comprehensive project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+
+For detailed documentation see [docs](docs/README.md).
+
 ## Getting Started
 
 First, run the development server:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation Index
+
+This directory contains detailed documentation for the CareersRing project. Start by reading `overview.md` and then explore individual topics.
+
+- [Overview](overview.md) – high level summary of the repository and its components
+- [Frontend](frontend.md) – Next.js application structure
+- [Backend](backend.md) – Go API structure and endpoints
+- [Database](database.md) – database configuration and models
+- [Deployment](deployment.md) – scripts and production usage
+- [Testing](testing.md) – how to run and interpret tests

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,17 @@
+# Backend (Go API)
+
+The `api/` directory implements a REST API using the Gin web framework.
+
+Key packages:
+
+- `main.go` – entry point configuring the router and database.
+- `router/` – defines all HTTP routes.
+- `db/` – handles connection to SQLite or Postgres based on environment variables.
+- `candidate/`, `client/`, `hcm/`, `authentication/`, `masterData/` – packages with models and controllers for different resources.
+- `models/` – Gorm models shared across packages.
+
+Run the API in development with:
+
+```bash
+DB_TYPE=sqlite3 go run ./api
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,8 @@
+# Database
+
+The API uses Gorm for ORM functionality. The database backend is selected at runtime with the `DB_TYPE` environment variable:
+
+- `sqlite3` – default for local development. The database file path can be overridden with `SQLITE_PATH`.
+- `postgres` – used in production. Connection parameters default to a local Postgres instance but can be provided via `POSTGRES_DSN`.
+
+Models are defined in `api/models`. `models.MigrateDB` is called on startup to create tables.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,20 @@
+# Deployment
+
+Use the helper scripts in the `scripts/` directory to build and run the project.
+
+- `scripts/deploy.sh` – installs dependencies, builds the Next.js app and compiles the Go API into a `careersring-api` binary. Environment variables are set for production usage.
+- `scripts/run.sh` – runs the compiled Go binary and the Next.js server together. Used by the systemd service.
+- `scripts/register_service.sh` – creates `/etc/systemd/system/careersring.service` pointing to `run.sh` so the application can run as a service.
+- `scripts/init_sqlite.go` – seeds a local SQLite database with sample data for development.
+
+Build for production:
+
+```bash
+./scripts/deploy.sh
+```
+
+Run locally after building:
+
+```bash
+./scripts/run.sh
+```

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,13 @@
+# Frontend (Next.js)
+
+The `src/` directory houses the Next.js code. Important subfolders:
+
+- `src/app` – new Next.js app router pages.
+  - `page.js` – landing page.
+  - `layout.js` – global layout and font configuration.
+  - `components/` – shared React components such as the multi-step form.
+  - `forms/` – classic single-page candidate form used in tests.
+  - `admin/` – administrative UI for searching and editing candidates.
+  - `POC/` – proof‑of‑concept route rendering `FounditForm`.
+
+Testing for the frontend is done with Jest and React Testing Library. Run `npm test` to execute the suite.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,8 @@
+# Overview
+
+CareersRing combines a Next.js frontend with a Go API to manage candidate data for recruitment workflows. The repository is organized into two main parts:
+
+1. `src/` – the Next.js application containing pages, components and forms.
+2. `api/` – a Go module exposing REST endpoints using the Gin framework.
+
+Scripts in the `scripts/` directory help with local development, building for production and deploying as a systemd service.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,9 @@
+# Testing
+
+The frontend uses Jest with React Testing Library. To run the tests:
+
+```bash
+npm test
+```
+
+Tests are located in the `__tests__/` directory. Currently a single test verifies basic validation on the candidate form.


### PR DESCRIPTION
## Summary
- link to new docs from README
- add documentation covering project structure, frontend, backend, database, deployment and testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68847ea0f67883309f4a951f68cb523b