### PR TITLE
Fix admin dashboard links

### DIFF
--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -1,11 +1,17 @@
+import Link from 'next/link';
+
 export default function AdminHome() {
   return (
-    <div style={{padding: '2rem'}}>
+    <div style={{ padding: '2rem' }}>
       <h1>Admin Dashboard</h1>
       <p>Use the links below to manage the system.</p>
       <ul>
-        <li><a href="/admin/candidates">Search Candidates</a></li>
-        <li><a href="/admin/invite">Send Invitations</a></li>
+        <li>
+          <Link href="/admin/candidates">Search Candidates</Link>
+        </li>
+        <li>
+          <Link href="/admin/invite">Send Invitations</Link>
+        </li>
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix `<a>` navigation warnings in `AdminHome`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848e7faffc83309e1cde3aaef9e018